### PR TITLE
Modify gulpfile.js: Refactor deprecated code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ gulp.task("build", function() {
     return gulp.src([
         "src/**/*.ts"
     ])
-    .pipe(tsc(tstProject))
+    .pipe(tstProject())
     .on("error", function (err) {
         process.exit(1);
     })


### PR DESCRIPTION
gulp-typescript: ts(tsProject) has been deprecated - use
.pipe(tsProject(reporter)) instead
  As of gulp-typescript 3.0, .pipe(ts(tsProject)) should be written as
.pipe(tsProject()).
More information: http://dev.ivogabe.com/gulp-typescript-3/